### PR TITLE
== 로 비교하던 문자열을 equals로 비교하게끔 만들었다.

### DIFF
--- a/src/main/java/com/lhs/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/lhs/service/impl/BoardServiceImpl.java
@@ -85,7 +85,7 @@ public class BoardServiceImpl implements BoardService{
 		System.out.println(write);
 		System.out.println();
 		for(MultipartFile mFile: mFiles) {
-			if(mFile.getSize() == 0 ||mFile.getOriginalFilename()== "" )
+			if(mFile.getSize() == 0 || "".equals(mFile.getOriginalFilename()))
 				continue;
 			BoardAttach boardAttach = new BoardAttach();
 			boardAttach.setBoardSeq(boardDto.getBoardSeq());  // boardSeq
@@ -150,7 +150,7 @@ public class BoardServiceImpl implements BoardService{
 		
 		int result = 0;
 		for(MultipartFile mFile: mFiles) {
-			if(mFile.getSize() == 0 ||mFile.getOriginalFilename()== "" )
+			if(mFile.getSize() == 0 || "".equals(mFile.getOriginalFilename()) )
 				continue;
 			System.out.println(" 첨부파일 업데이트  시작이요 ! ");
 			BoardAttach boardAttach = new BoardAttach();


### PR DESCRIPTION
문자열을 비교할 때 == 연산자는 두 문자열 객체의 참조(주소)를 비교합니다. 따라서, 문자열 리터럴 또는 String Pool에 있는 같은 문자열을 참조하는 경우에만 true를 반환합니다.
문자열의 내용 자체를 비교하기 위해서는 equals() 메소드를 사용해야 합니다. equals() 메소드는 두 문자열의 내용이 동일한지 비교하여, 내용이 같다면 true를 반환합니다.